### PR TITLE
Add python-setuptools to ansible install script

### DIFF
--- a/scripts/ansible.sh
+++ b/scripts/ansible.sh
@@ -4,4 +4,4 @@
 rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 
 # Install Ansible.
-yum -y install ansible
+yum -y install ansible python-setuptools


### PR DESCRIPTION
Without setuptools available, the ansible provisioner run will fail with the following error on CentOS 6.5 minimal:

> ==> virtualbox-iso: Provisioning with Ansible...
>    virtualbox-iso: Creating Ansible staging directory...
>    virtualbox-iso: Creating directory: /tmp/packer-provisioner-ansible-local
>    virtualbox-iso: Uploading main Playbook file...
>    virtualbox-iso: Uploading role directories...
>    virtualbox-iso: Creating directory: /tmp/packer-provisioner-ansible-local/roles/geerlingguy.packer-rhel
>    virtualbox-iso: Executing Ansible: ansible-playbook /tmp/packer-provisioner-ansible-local/main.yml -c local -i "127.0.0.1,"
>    virtualbox-iso: Traceback (most recent call last):
>    virtualbox-iso: File "/usr/bin/ansible-playbook", line 22, in <module>
>    virtualbox-iso: import pkg_resources
>    virtualbox-iso: ImportError: No module named pkg_resources
> ==> virtualbox-iso: Unregistering and deleting virtual machine...
> ==> virtualbox-iso: Deleting output directory...
> Build 'virtualbox-iso' errored: Error executing Ansible: Non-zero exit status: 1

This commit adds python-setuptools to the ansible install script.
